### PR TITLE
Update the apis to adapters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,11 +49,11 @@ boot-core = { version = "0.10.0" }
 
 tokio = { version = "1.4", features = ["full"] }
 
-abstract-testing = { version = "0.14" }
-abstract-core = { version = "0.14" }
-abstract-boot = { version = "0.14" }
-abstract-sdk = { version = "0.14" }
-abstract-api = { version = "0.14" }
+abstract-testing = { git = "https://github.com/AbstractSDK/contracts", rev = "f1294de04b570a2d7f847e7b552ac5e21318cf00" }
+abstract-core = { git = "https://github.com/AbstractSDK/contracts", rev = "f1294de04b570a2d7f847e7b552ac5e21318cf00" }
+abstract-boot = { git = "https://github.com/AbstractSDK/contracts", rev = "f1294de04b570a2d7f847e7b552ac5e21318cf00" }
+abstract-sdk = { git = "https://github.com/AbstractSDK/contracts", rev = "f1294de04b570a2d7f847e7b552ac5e21318cf00" }
+abstract-adapter = { git = "https://github.com/AbstractSDK/contracts", rev = "f1294de04b570a2d7f847e7b552ac5e21318cf00" }
 
 ## Testing
 rstest = "0.16.0"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Apis
+# Abstract Adapter Modules
 
-<a href="https://codecov.io/gh/AbstractSDK/apis" > 
- <img src="https://codecov.io/gh/AbstractSDK/apis/branch/main/graph/badge.svg?token=JIGGY3O2I7"/> 
+<a href="https://codecov.io/gh/AbstractSDK/adapters" > 
+ <img src="https://codecov.io/gh/AbstractSDK/adapters/branch/main/graph/badge.svg?token=JIGGY3O2I7"/> 
  </a>
 
-APIs are smart-contracts that offer an interface or feature that is user-agnostic. There contracts are not migratable and have no admin assigned to them.  
+Adapter modules are smart-contracts that offer an interface or feature that is user-agnostic. There contracts are not migratable and have no admin assigned to them.  
 Therefore their usage is fully permissionless.

--- a/contracts/cw-staking/Cargo.toml
+++ b/contracts/cw-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "abstract-cw-staking-api"
-description = "Cw-staking is a Abstract api for staking tokens."
+name = "abstract-cw-staking"
+description = "Cw-staking is a Abstract adapter for staking tokens."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
@@ -51,7 +51,7 @@ serde = { workspace = true }
 
 abstract-sdk = { workspace = true }
 abstract-core = { workspace = true }
-abstract-api = { workspace = true }
+abstract-adapter = { workspace = true }
 abstract-boot = { workspace = true, optional = true }
 boot-core = { workspace = true, optional = true }
 
@@ -91,7 +91,7 @@ clap = { workspace = true }
 cw-staking = { path = ".", features = [
   "boot",
   "juno",
-], package = "abstract-cw-staking-api" }
+], package = "abstract-cw-staking" }
 abstract-sdk = { workspace = true, features = ["test-utils"] }
 abstract-testing = { workspace = true }
 wyndex-bundle = { git = "https://github.com/AbstractSDK/integration-bundles.git" }

--- a/contracts/cw-staking/README.md
+++ b/contracts/cw-staking/README.md
@@ -1,6 +1,6 @@
 # CosmWasm Staking
 
-An Abstract-API contract that handles staking and unbonding interactions with staking providers. 
+An Abstract Adapter module that handles staking and unbonding interactions with staking providers. 
 
 ## Naming Convention
 

--- a/contracts/cw-staking/examples/deploy.rs
+++ b/contracts/cw-staking/examples/deploy.rs
@@ -1,16 +1,13 @@
 use abstract_boot::boot_core::{
     instantiate_daemon_env, networks::NetworkInfo, DaemonOptionsBuilder, *,
 };
-use abstract_boot::{AnsHost, AdapterDeployer, VCExecFns, VersionControl};
+use abstract_boot::{AdapterDeployer, AnsHost, VCExecFns, VersionControl};
 use abstract_cw_staking::boot::CwStakingAdapter;
 use abstract_cw_staking::CW_STAKING;
-use abstract_sdk::{
-    core::{
-        objects::module::{Module, ModuleInfo, ModuleVersion},
-        adapter,
-        ANS_HOST,
-        VERSION_CONTROL
-    }
+use abstract_sdk::core::{
+    adapter,
+    objects::module::{Module, ModuleInfo, ModuleVersion},
+    ANS_HOST, VERSION_CONTROL,
 };
 use cosmwasm_std::{Addr, Empty};
 use semver::Version;
@@ -47,7 +44,7 @@ fn deploy_cw_staking(
             version: ModuleVersion::from(CONTRACT_VERSION),
             ..info
         };
-        version_control.add_modules(vec![(new_info, reference)])?;
+        version_control.propose_modules(vec![(new_info, reference)])?;
     } else if let Some(code_id) = code_id {
         let mut cw_staking = CwStakingAdapter::new(CW_STAKING, chain);
         cw_staking.set_code_id(code_id);

--- a/contracts/cw-staking/examples/deploy.rs
+++ b/contracts/cw-staking/examples/deploy.rs
@@ -1,11 +1,17 @@
 use abstract_boot::boot_core::{
     instantiate_daemon_env, networks::NetworkInfo, DaemonOptionsBuilder, *,
 };
-use abstract_boot::{AnsHost, ApiDeployer, VCExecFns, VersionControl};
-use abstract_cw_staking_api::boot::CwStakingApi;
-use abstract_cw_staking_api::CW_STAKING;
-use abstract_sdk::core::objects::module::{Module, ModuleInfo, ModuleVersion};
-use abstract_sdk::core::{api, ANS_HOST, VERSION_CONTROL};
+use abstract_boot::{AnsHost, AdapterDeployer, VCExecFns, VersionControl};
+use abstract_cw_staking::boot::CwStakingAdapter;
+use abstract_cw_staking::CW_STAKING;
+use abstract_sdk::{
+    core::{
+        objects::module::{Module, ModuleInfo, ModuleVersion},
+        adapter,
+        ANS_HOST,
+        VERSION_CONTROL
+    }
+};
 use cosmwasm_std::{Addr, Empty};
 use semver::Version;
 use std::sync::Arc;
@@ -43,11 +49,11 @@ fn deploy_cw_staking(
         };
         version_control.add_modules(vec![(new_info, reference)])?;
     } else if let Some(code_id) = code_id {
-        let mut cw_staking = CwStakingApi::new(CW_STAKING, chain);
+        let mut cw_staking = CwStakingAdapter::new(CW_STAKING, chain);
         cw_staking.set_code_id(code_id);
-        let init_msg = api::InstantiateMsg {
+        let init_msg = adapter::InstantiateMsg {
             module: Empty {},
-            base: api::BaseInstantiateMsg {
+            base: adapter::BaseInstantiateMsg {
                 ans_host_address: ans_host.address()?.into(),
                 version_control_address: version_control.address()?.into(),
             },
@@ -56,11 +62,11 @@ fn deploy_cw_staking(
             .as_instance_mut()
             .instantiate(&init_msg, None, None)?;
 
-        version_control.register_apis(vec![cw_staking.as_instance_mut()], &module_version)?;
+        version_control.register_adapters(vec![cw_staking.as_instance_mut()], &module_version)?;
     } else {
         log::info!("Uploading Cw staking");
         // Upload and deploy with the version
-        let mut cw_staking = CwStakingApi::new(CW_STAKING, chain);
+        let mut cw_staking = CwStakingAdapter::new(CW_STAKING, chain);
 
         cw_staking.deploy(module_version, Empty {})?;
     }

--- a/contracts/cw-staking/examples/schema.rs
+++ b/contracts/cw-staking/examples/schema.rs
@@ -1,4 +1,4 @@
-use abstract_cw_staking_api::contract::CwStakingApi;
+use abstract_cw_staking::contract::CwStakingAdapter;
 use cosmwasm_schema::remove_schemas;
 use std::env::current_dir;
 use std::fs::create_dir_all;
@@ -9,5 +9,5 @@ fn main() {
     create_dir_all(&out_dir).unwrap();
     remove_schemas(&out_dir).unwrap();
 
-    CwStakingApi::export_schema(&out_dir);
+    CwStakingAdapter::export_schema(&out_dir);
 }

--- a/contracts/cw-staking/src/contract.rs
+++ b/contracts/cw-staking/src/contract.rs
@@ -1,18 +1,18 @@
 use crate::msg::{CwStakingExecuteMsg, CwStakingQueryMsg};
 use crate::CW_STAKING;
 use crate::{error::StakingError, handlers};
-use abstract_api::{export_endpoints, ApiContract};
+use abstract_adapter::{export_endpoints, AdapterContract};
 use cosmwasm_std::{Empty, Response};
 
 const MODULE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-pub type CwStakingApi = ApiContract<StakingError, Empty, CwStakingExecuteMsg, CwStakingQueryMsg>;
+pub type CwStakingAdapter = AdapterContract<StakingError, Empty, CwStakingExecuteMsg, CwStakingQueryMsg>;
 pub type CwStakingResult<T = Response> = Result<T, StakingError>;
 
-pub const CW_STAKING_API: CwStakingApi = CwStakingApi::new(CW_STAKING, MODULE_VERSION, None)
+pub const CW_STAKING_ADAPTER: CwStakingAdapter = CwStakingAdapter::new(CW_STAKING, MODULE_VERSION, None)
     .with_execute(handlers::execute_handler)
     .with_query(handlers::query_handler);
 
 // Export the endpoints for this contract
 #[cfg(feature = "export")]
-export_endpoints!(CW_STAKING_API, CwStakingApi);
+export_endpoints!(CW_STAKING_ADAPTER, CwStakingAdapter);

--- a/contracts/cw-staking/src/contract.rs
+++ b/contracts/cw-staking/src/contract.rs
@@ -6,12 +6,14 @@ use cosmwasm_std::{Empty, Response};
 
 const MODULE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-pub type CwStakingAdapter = AdapterContract<StakingError, Empty, CwStakingExecuteMsg, CwStakingQueryMsg>;
+pub type CwStakingAdapter =
+    AdapterContract<StakingError, Empty, CwStakingExecuteMsg, CwStakingQueryMsg>;
 pub type CwStakingResult<T = Response> = Result<T, StakingError>;
 
-pub const CW_STAKING_ADAPTER: CwStakingAdapter = CwStakingAdapter::new(CW_STAKING, MODULE_VERSION, None)
-    .with_execute(handlers::execute_handler)
-    .with_query(handlers::query_handler);
+pub const CW_STAKING_ADAPTER: CwStakingAdapter =
+    CwStakingAdapter::new(CW_STAKING, MODULE_VERSION, None)
+        .with_execute(handlers::execute_handler)
+        .with_query(handlers::query_handler);
 
 // Export the endpoints for this contract
 #[cfg(feature = "export")]

--- a/contracts/cw-staking/src/error.rs
+++ b/contracts/cw-staking/src/error.rs
@@ -1,4 +1,4 @@
-use abstract_api::ApiError;
+use abstract_adapter::AdapterError;
 use abstract_sdk::AbstractSdkError;
 use cosmwasm_std::StdError;
 use cw_asset::AssetError;
@@ -10,7 +10,7 @@ pub enum StakingError {
     Std(#[from] StdError),
 
     #[error("{0}")]
-    ApiError(#[from] ApiError),
+    AdapterError(#[from] AdapterError),
 
     #[error("{0}")]
     AbstractError(#[from] AbstractSdkError),

--- a/contracts/cw-staking/src/handlers/execute.rs
+++ b/contracts/cw-staking/src/handlers/execute.rs
@@ -1,4 +1,4 @@
-use crate::contract::{CwStakingApi, CwStakingResult};
+use crate::contract::{CwStakingAdapter, CwStakingResult};
 use crate::msg::{CwStakingAction, CwStakingExecuteMsg, ProviderName, IBC_STAKING_PROVIDER_ID};
 use crate::providers::resolver::{self, is_over_ibc};
 use crate::LocalCwStaking;
@@ -14,7 +14,7 @@ pub fn execute_handler(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
-    api: CwStakingApi,
+    adapter: CwStakingAdapter,
     msg: CwStakingExecuteMsg,
 ) -> CwStakingResult {
     let CwStakingExecuteMsg {
@@ -23,26 +23,26 @@ pub fn execute_handler(
     } = msg;
     // if provider is on an app-chain, execute the action on the app-chain
     if is_over_ibc(&provider_name)? {
-        handle_ibc_request(&deps, info, &api, provider_name, &action)
+        handle_ibc_request(&deps, info, &adapter, provider_name, &action)
     } else {
         // the action can be executed on the local chain
-        handle_local_request(deps, env, info, api, action, provider_name)
+        handle_local_request(deps, env, info, adapter, action, provider_name)
     }
 }
 
-/// Handle an api request that can be executed on the local chain
+/// Handle an adapter request that can be executed on the local chain
 fn handle_local_request(
     deps: DepsMut,
     env: Env,
     _info: MessageInfo,
-    api: CwStakingApi,
+    adapter: CwStakingAdapter,
     action: CwStakingAction,
     provider_name: String,
 ) -> CwStakingResult {
     let provider = resolver::resolve_local_provider(&provider_name)?;
     let response =
-        Response::new().add_submessage(api.resolve_staking_action(deps, env, action, provider)?);
-    Ok(api.custom_tag_response(
+        Response::new().add_submessage(adapter.resolve_staking_action(deps, env, action, provider)?);
+    Ok(adapter.custom_tag_response(
         response,
         "handle_local_request",
         vec![("provider", provider_name)],
@@ -53,13 +53,13 @@ fn handle_local_request(
 fn handle_ibc_request(
     deps: &DepsMut,
     info: MessageInfo,
-    api: &CwStakingApi,
+    adapter: &CwStakingAdapter,
     provider_name: ProviderName,
     action: &CwStakingAction,
 ) -> CwStakingResult {
     let host_chain = provider_name.clone();
-    let ans = api.name_service(deps.as_ref());
-    let ibc_client = api.ibc_client(deps.as_ref());
+    let ans = adapter.name_service(deps.as_ref());
+    let ibc_client = adapter.ibc_client(deps.as_ref());
     // get the to-be-sent assets from the action
     let coins = resolve_assets_to_transfer(deps.as_ref(), action, ans.host())?;
     // construct the ics20 call(s)
@@ -81,7 +81,7 @@ fn handle_ibc_request(
 
     // call both messages on the proxy
     let response = Response::new().add_messages(vec![ics20_transfer_msg, ibc_action_msg]);
-    Ok(api.custom_tag_response(
+    Ok(adapter.custom_tag_response(
         response,
         "handle_ibc_request",
         vec![("provider", provider_name)],

--- a/contracts/cw-staking/src/handlers/execute.rs
+++ b/contracts/cw-staking/src/handlers/execute.rs
@@ -40,8 +40,8 @@ fn handle_local_request(
     provider_name: String,
 ) -> CwStakingResult {
     let provider = resolver::resolve_local_provider(&provider_name)?;
-    let response =
-        Response::new().add_submessage(adapter.resolve_staking_action(deps, env, action, provider)?);
+    let response = Response::new()
+        .add_submessage(adapter.resolve_staking_action(deps, env, action, provider)?);
     Ok(adapter.custom_tag_response(
         response,
         "handle_local_request",

--- a/contracts/cw-staking/src/handlers/query.rs
+++ b/contracts/cw-staking/src/handlers/query.rs
@@ -1,6 +1,6 @@
 use crate::msg::CwStakingQueryMsg;
 use crate::{
-    contract::{CwStakingApi, CwStakingResult},
+    contract::{CwStakingAdapter, CwStakingResult},
     providers::resolver::{self, is_over_ibc},
 };
 use abstract_sdk::features::AbstractNameService;
@@ -9,7 +9,7 @@ use cosmwasm_std::{to_binary, Binary, Deps, Env, StdError};
 pub fn query_handler(
     deps: Deps,
     env: Env,
-    app: &CwStakingApi,
+    app: &CwStakingAdapter,
     msg: CwStakingQueryMsg,
 ) -> CwStakingResult<Binary> {
     let name_service = app.name_service(deps);

--- a/contracts/cw-staking/src/lib.rs
+++ b/contracts/cw-staking/src/lib.rs
@@ -23,26 +23,26 @@ pub mod boot {
     use abstract_boot::boot_core::ContractWrapper;
     use abstract_boot::boot_core::{contract, ContractInstance};
     use abstract_boot::boot_core::{Contract, CwEnv, IndexResponse, TxResponse};
-    use abstract_boot::{AbstractBootError, ApiDeployer, Manager};
+    use abstract_boot::{AbstractBootError, AdapterDeployer, Manager};
     use abstract_core::objects::{AnsAsset, AssetEntry};
-    use abstract_core::{api, MANAGER};
+    use abstract_core::{adapter, MANAGER};
     use cosmwasm_std::{Addr, Empty};
 
     /// Contract wrapper for interacting with BOOT
     #[contract(InstantiateMsg, ExecuteMsg, QueryMsg, Empty)]
-    pub struct CwStakingApi;
+    pub struct CwStakingAdapter<Chain>;
 
-    impl<Chain: CwEnv> ApiDeployer<Chain, Empty> for CwStakingApi<Chain> {}
+    impl<Chain: CwEnv> AdapterDeployer<Chain, Empty> for CwStakingAdapter<Chain> {}
 
     /// implement chain-generic functions
-    impl<Chain: CwEnv> CwStakingApi<Chain>
+    impl<Chain: CwEnv> CwStakingAdapter<Chain>
     where
         TxResponse<Chain>: IndexResponse,
     {
         pub fn new(id: &str, chain: Chain) -> Self {
             Self(
                 Contract::new(id, chain)
-                    .with_wasm_path("abstract_cw_staking_api")
+                    .with_wasm_path("abstract_cw_staking")
                     .with_mock(Box::new(ContractWrapper::new_with_empty(
                         crate::contract::execute,
                         crate::contract::instantiate,
@@ -63,7 +63,7 @@ pub mod boot {
             duration: Option<cw_utils::Duration>,
         ) -> Result<(), AbstractBootError> {
             let manager = Manager::new(MANAGER, self.get_chain().clone());
-            let stake_msg = crate::msg::ExecuteMsg::Module(api::ApiRequestMsg {
+            let stake_msg = crate::msg::ExecuteMsg::Module(adapter::AdapterRequestMsg {
                 proxy_address: None,
                 request: CwStakingExecuteMsg {
                     provider,
@@ -84,7 +84,7 @@ pub mod boot {
             duration: Option<cw_utils::Duration>,
         ) -> Result<(), AbstractBootError> {
             let manager = Manager::new(MANAGER, self.get_chain().clone());
-            let stake_msg = crate::msg::ExecuteMsg::Module(api::ApiRequestMsg {
+            let stake_msg = crate::msg::ExecuteMsg::Module(adapter::AdapterRequestMsg {
                 proxy_address: None,
                 request: CwStakingExecuteMsg {
                     provider,
@@ -104,7 +104,7 @@ pub mod boot {
             provider: String,
         ) -> Result<(), AbstractBootError> {
             let manager = Manager::new(MANAGER, self.get_chain().clone());
-            let claim_msg = crate::msg::ExecuteMsg::Module(api::ApiRequestMsg {
+            let claim_msg = crate::msg::ExecuteMsg::Module(adapter::AdapterRequestMsg {
                 proxy_address: None,
                 request: CwStakingExecuteMsg {
                     provider,
@@ -123,7 +123,7 @@ pub mod boot {
             provider: String,
         ) -> Result<(), AbstractBootError> {
             let manager = Manager::new(MANAGER, self.get_chain().clone());
-            let claim_rewards_msg = crate::msg::ExecuteMsg::Module(api::ApiRequestMsg {
+            let claim_rewards_msg = crate::msg::ExecuteMsg::Module(adapter::AdapterRequestMsg {
                 proxy_address: None,
                 request: CwStakingExecuteMsg {
                     provider,

--- a/contracts/cw-staking/src/msg.rs
+++ b/contracts/cw-staking/src/msg.rs
@@ -1,8 +1,8 @@
-//! # Staking Api
+//! # Staking Adapter
 //!
 //! `4t2::cw-staking`
 
-use abstract_core::api;
+use abstract_core::adapter;
 use abstract_core::objects::{AnsAsset, AssetEntry};
 use cosmwasm_schema::QueryResponses;
 use cosmwasm_std::{Addr, Empty, Uint128};
@@ -15,15 +15,15 @@ pub type ProviderName = String;
 /// The callback id for staking over ibc
 pub const IBC_STAKING_PROVIDER_ID: u32 = 22335;
 
-pub type ExecuteMsg = api::ExecuteMsg<CwStakingExecuteMsg>;
-pub type InstantiateMsg = api::InstantiateMsg<Empty>;
-pub type QueryMsg = api::QueryMsg<CwStakingQueryMsg>;
+pub type ExecuteMsg = adapter::ExecuteMsg<CwStakingExecuteMsg>;
+pub type InstantiateMsg = adapter::InstantiateMsg<Empty>;
+pub type QueryMsg = adapter::QueryMsg<CwStakingQueryMsg>;
 
-impl api::ApiExecuteMsg for CwStakingExecuteMsg {}
+impl adapter::AdapterExecuteMsg for CwStakingExecuteMsg {}
 
-impl api::ApiQueryMsg for CwStakingQueryMsg {}
+impl adapter::AdapterQueryMsg for CwStakingQueryMsg {}
 
-/// A request message that's sent to this staking api
+/// A request message that's sent to this staking adapter
 #[cosmwasm_schema::cw_serde]
 pub struct CwStakingExecuteMsg {
     /// The name of the staking provider

--- a/contracts/cw-staking/tests/common/mod.rs
+++ b/contracts/cw-staking/tests/common/mod.rs
@@ -7,7 +7,9 @@ use abstract_core::objects::gov_type::GovernanceDetails;
 use abstract_boot::boot_core::Mock;
 use cosmwasm_std::Addr;
 
-pub fn create_default_account(factory: &AccountFactory<Mock>) -> anyhow::Result<AbstractAccount<Mock>> {
+pub fn create_default_account(
+    factory: &AccountFactory<Mock>,
+) -> anyhow::Result<AbstractAccount<Mock>> {
     let os = factory.create_default_account(GovernanceDetails::Monarchy {
         monarch: Addr::unchecked(ROOT_USER).to_string(),
     })?;

--- a/contracts/cw-staking/tests/common/mod.rs
+++ b/contracts/cw-staking/tests/common/mod.rs
@@ -7,7 +7,7 @@ use abstract_core::objects::gov_type::GovernanceDetails;
 use abstract_boot::boot_core::Mock;
 use cosmwasm_std::Addr;
 
-pub fn create_default_os(factory: &AccountFactory<Mock>) -> anyhow::Result<AbstractAccount<Mock>> {
+pub fn create_default_account(factory: &AccountFactory<Mock>) -> anyhow::Result<AbstractAccount<Mock>> {
     let os = factory.create_default_account(GovernanceDetails::Monarchy {
         monarch: Addr::unchecked(ROOT_USER).to_string(),
     })?;

--- a/contracts/dex/Cargo.toml
+++ b/contracts/dex/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "abstract-dex-api"
+name = "abstract-dex-adapter"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
@@ -36,7 +36,7 @@ cw-storage-plus = { workspace = true }
 abstract-boot = { workspace = true, optional = true }
 abstract-core = { workspace = true }
 abstract-sdk = { workspace = true }
-abstract-api = { workspace = true }
+abstract-adapter = { workspace = true }
 boot-core = { workspace = true, optional = true }
 
 # Juno dexes #
@@ -65,5 +65,5 @@ clap = { workspace = true }
 wyndex-bundle = { git = "https://github.com/AbstractSDK/integration-bundles.git" }
 abstract-testing = { workspace = true }
 abstract-sdk = { workspace = true, features = ["test-utils"] }
-dex = { path = ".", features = ["boot", "juno"], package = "abstract-dex-api" }
+dex = { path = ".", features = ["boot", "juno"], package = "abstract-dex-adapter" }
 boot-cw-plus = { workspace = true }

--- a/contracts/dex/README.md
+++ b/contracts/dex/README.md
@@ -1,8 +1,8 @@
-# TendermintStake Api
+# Dex Adapter Module
 
-Api to easily delegate and claim rewards from validators.
+Adapter module to interact with dexes across the Cosmos
 
 # Features
-
-- Claim all rewards in one go
-- (TODO) claim and swap to a specific asset in one go
+- Swap
+- Provide Liquidity
+- Withdraw Liquidity

--- a/contracts/dex/examples/deploy.rs
+++ b/contracts/dex/examples/deploy.rs
@@ -2,11 +2,7 @@ use abstract_boot::AdapterDeployer;
 
 use abstract_boot::boot_core::networks::{parse_network, NetworkInfo};
 use abstract_boot::boot_core::*;
-use abstract_dex_adapter::{
-    boot::DexAdapter,
-    msg::DexInstantiateMsg,
-    EXCHANGE
-};
+use abstract_dex_adapter::{boot::DexAdapter, msg::DexInstantiateMsg, EXCHANGE};
 use cosmwasm_std::Decimal;
 use semver::Version;
 use std::sync::Arc;

--- a/contracts/dex/examples/deploy.rs
+++ b/contracts/dex/examples/deploy.rs
@@ -1,10 +1,12 @@
-use abstract_boot::ApiDeployer;
+use abstract_boot::AdapterDeployer;
 
 use abstract_boot::boot_core::networks::{parse_network, NetworkInfo};
 use abstract_boot::boot_core::*;
-use abstract_dex_api::boot::DexApi;
-use abstract_dex_api::msg::DexInstantiateMsg;
-use abstract_dex_api::EXCHANGE;
+use abstract_dex_adapter::{
+    boot::DexAdapter,
+    msg::DexInstantiateMsg,
+    EXCHANGE
+};
 use cosmwasm_std::Decimal;
 use semver::Version;
 use std::sync::Arc;
@@ -17,7 +19,7 @@ fn deploy_dex(network: NetworkInfo) -> anyhow::Result<()> {
     let rt = Arc::new(Runtime::new()?);
     let options = DaemonOptionsBuilder::default().network(network).build();
     let (_sender, chain) = instantiate_daemon_env(&rt, options?)?;
-    let mut dex = DexApi::new(EXCHANGE, chain);
+    let mut dex = DexAdapter::new(EXCHANGE, chain);
     dex.deploy(
         version,
         DexInstantiateMsg {

--- a/contracts/dex/examples/deploy.rs
+++ b/contracts/dex/examples/deploy.rs
@@ -24,7 +24,7 @@ fn deploy_dex(network: NetworkInfo) -> anyhow::Result<()> {
         version,
         DexInstantiateMsg {
             swap_fee: Decimal::percent(1),
-            recipient_os: 0,
+            recipient_account: 0,
         },
     )?;
     Ok(())

--- a/contracts/dex/examples/schema.rs
+++ b/contracts/dex/examples/schema.rs
@@ -11,5 +11,9 @@ fn main() {
     remove_schemas(&out_dir).unwrap();
 
     DexAdapter::export_schema(&out_dir);
-    export_schema_with_title(&schema_for!(SimulateSwapResponse), &out_dir, "AdapterResponse");
+    export_schema_with_title(
+        &schema_for!(SimulateSwapResponse),
+        &out_dir,
+        "AdapterResponse",
+    );
 }

--- a/contracts/dex/examples/schema.rs
+++ b/contracts/dex/examples/schema.rs
@@ -1,5 +1,5 @@
-use abstract_dex_api::contract::DexApi;
-use abstract_dex_api::msg::SimulateSwapResponse;
+use abstract_dex_adapter::contract::DexAdapter;
+use abstract_dex_adapter::msg::SimulateSwapResponse;
 use cosmwasm_schema::{export_schema_with_title, remove_schemas, schema_for};
 use std::env::current_dir;
 use std::fs::create_dir_all;
@@ -10,6 +10,6 @@ fn main() {
     create_dir_all(&out_dir).unwrap();
     remove_schemas(&out_dir).unwrap();
 
-    DexApi::export_schema(&out_dir);
-    export_schema_with_title(&schema_for!(SimulateSwapResponse), &out_dir, "ApiResponse");
+    DexAdapter::export_schema(&out_dir);
+    export_schema_with_title(&schema_for!(SimulateSwapResponse), &out_dir, "AdapterResponse");
 }

--- a/contracts/dex/src/api.rs
+++ b/contracts/dex/src/api.rs
@@ -8,7 +8,7 @@ use crate::{
     EXCHANGE,
 };
 use abstract_core::objects::{module::ModuleId, AssetEntry};
-use abstract_sdk::{AdapterInterface};
+use abstract_sdk::AdapterInterface;
 use abstract_sdk::{
     features::{AccountIdentification, Dependencies},
     AbstractSdkResult,
@@ -158,7 +158,7 @@ mod test {
     fn expected_request_with_test_proxy(request: DexExecuteMsg) -> ExecuteMsg {
         AdapterRequestMsg {
             proxy_address: Some(abstract_testing::prelude::TEST_PROXY.to_string()),
-            request: request.into(),
+            request,
         }
         .into()
     }

--- a/contracts/dex/src/api.rs
+++ b/contracts/dex/src/api.rs
@@ -57,9 +57,9 @@ impl<'a, T: DexInterface> Dex<'a, T> {
         self.dex_module_id
     }
     fn request(&self, action: DexAction) -> AbstractSdkResult<CosmosMsg> {
-        let modules = self.base.adapters(self.deps);
+        let adapters = self.base.adapters(self.deps);
 
-        modules.request(
+        adapters.request(
             self.dex_module_id(),
             DexExecuteMsg::Action {
                 dex: self.dex_name(),

--- a/contracts/dex/src/api.rs
+++ b/contracts/dex/src/api.rs
@@ -8,7 +8,7 @@ use crate::{
     EXCHANGE,
 };
 use abstract_core::objects::{module::ModuleId, AssetEntry};
-use abstract_sdk::ApiInterface;
+use abstract_sdk::{AdapterInterface};
 use abstract_sdk::{
     features::{AccountIdentification, Dependencies},
     AbstractSdkResult,
@@ -16,7 +16,7 @@ use abstract_sdk::{
 use cosmwasm_std::{CosmosMsg, Decimal, Deps, Uint128};
 use serde::de::DeserializeOwned;
 
-/// Interact with the dex api in your module.
+/// Interact with the dex adapter in your module.
 pub trait DexInterface: AccountIdentification + Dependencies {
     /// Construct a new dex interface
     /// Params:
@@ -57,7 +57,7 @@ impl<'a, T: DexInterface> Dex<'a, T> {
         self.dex_module_id
     }
     fn request(&self, action: DexAction) -> AbstractSdkResult<CosmosMsg> {
-        let modules = self.base.apis(self.deps);
+        let modules = self.base.adapters(self.deps);
 
         modules.request(
             self.dex_module_id(),
@@ -128,8 +128,8 @@ impl<'a, T: DexInterface> Dex<'a, T> {
 
 impl<'a, T: DexInterface> Dex<'a, T> {
     fn query<R: DeserializeOwned>(&self, query_msg: DexQueryMsg) -> AbstractSdkResult<R> {
-        let modules = self.base.apis(self.deps);
-        modules.query(EXCHANGE, query_msg)
+        let adapters = self.base.adapters(self.deps);
+        adapters.query(EXCHANGE, query_msg)
     }
     pub fn simulate_swap(
         &self,
@@ -149,14 +149,14 @@ impl<'a, T: DexInterface> Dex<'a, T> {
 mod test {
     use super::*;
     use crate::msg::ExecuteMsg;
-    use abstract_core::api::ApiRequestMsg;
+    use abstract_core::adapter::AdapterRequestMsg;
     use abstract_sdk::mock_module::MockModule;
     use cosmwasm_std::testing::mock_dependencies;
     use cosmwasm_std::wasm_execute;
     use speculoos::prelude::*;
 
     fn expected_request_with_test_proxy(request: DexExecuteMsg) -> ExecuteMsg {
-        ApiRequestMsg {
+        AdapterRequestMsg {
             proxy_address: Some(abstract_testing::prelude::TEST_PROXY.to_string()),
             request: request.into(),
         }

--- a/contracts/dex/src/contract.rs
+++ b/contracts/dex/src/contract.rs
@@ -1,18 +1,18 @@
 use crate::msg::{DexExecuteMsg, DexInstantiateMsg, DexQueryMsg};
 use crate::EXCHANGE;
 use crate::{error::DexError, handlers};
-use abstract_api::{export_endpoints, ApiContract};
+use abstract_adapter::{export_endpoints, AdapterContract};
 use cosmwasm_std::Response;
 
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-pub type DexApi = ApiContract<DexError, DexInstantiateMsg, DexExecuteMsg, DexQueryMsg>;
+pub type DexAdapter = AdapterContract<DexError, DexInstantiateMsg, DexExecuteMsg, DexQueryMsg>;
 pub type DexResult<T = Response> = Result<T, DexError>;
 
-pub const DEX_API: DexApi = DexApi::new(EXCHANGE, CONTRACT_VERSION, None)
+pub const DEX_ADAPTER: DexAdapter = DexAdapter::new(EXCHANGE, CONTRACT_VERSION, None)
     .with_instantiate(handlers::instantiate_handler)
     .with_execute(handlers::execute_handler)
     .with_query(handlers::query_handler);
 
 #[cfg(feature = "export")]
-export_endpoints!(DEX_API, DexApi);
+export_endpoints!(DEX_ADAPTER, DexAdapter);

--- a/contracts/dex/src/error.rs
+++ b/contracts/dex/src/error.rs
@@ -1,4 +1,4 @@
-use abstract_api::ApiError;
+use abstract_adapter::AdapterError;
 use abstract_core::objects::DexAssetPairing;
 use abstract_core::AbstractError;
 use abstract_sdk::AbstractSdkError;
@@ -21,7 +21,7 @@ pub enum DexError {
     Asset(#[from] AssetError),
 
     #[error("{0}")]
-    ApiError(#[from] ApiError),
+    AdapterError(#[from] AdapterError),
 
     #[error("DEX {0} is not a known dex on this network.")]
     UnknownDex(String),

--- a/contracts/dex/src/handlers/execute.rs
+++ b/contracts/dex/src/handlers/execute.rs
@@ -38,7 +38,7 @@ pub fn execute_handler(
         }
         DexExecuteMsg::UpdateFee {
             swap_fee,
-            recipient_account_id,
+            recipient_account: recipient_account_id,
         } => {
             // only previous OS can change the owner
             adapter.account_registry(deps.as_ref())

--- a/contracts/dex/src/handlers/execute.rs
+++ b/contracts/dex/src/handlers/execute.rs
@@ -41,7 +41,8 @@ pub fn execute_handler(
             recipient_account: recipient_account_id,
         } => {
             // only previous OS can change the owner
-            adapter.account_registry(deps.as_ref())
+            adapter
+                .account_registry(deps.as_ref())
                 .assert_proxy(&info.sender)?;
             if let Some(swap_fee) = swap_fee {
                 let mut fee = SWAP_FEE.load(deps.storage)?;
@@ -51,7 +52,9 @@ pub fn execute_handler(
 
             if let Some(account_id) = recipient_account_id {
                 let mut fee = SWAP_FEE.load(deps.storage)?;
-                let recipient = adapter.account_registry(deps.as_ref()).proxy_address(account_id)?;
+                let recipient = adapter
+                    .account_registry(deps.as_ref())
+                    .proxy_address(account_id)?;
                 fee.set_recipient(deps.api, recipient)?;
                 SWAP_FEE.save(deps.storage, &fee)?;
             }

--- a/contracts/dex/src/handlers/execute.rs
+++ b/contracts/dex/src/handlers/execute.rs
@@ -3,7 +3,7 @@ use crate::exchanges::exchange_resolver;
 use crate::msg::{DexAction, DexExecuteMsg, DexName, IBC_DEX_ID};
 use crate::LocalDex;
 use crate::{
-    contract::{DexApi, DexResult},
+    contract::{DexAdapter, DexResult},
     state::SWAP_FEE,
 };
 use abstract_core::ibc_client::CallbackInfo;
@@ -19,7 +19,7 @@ pub fn execute_handler(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
-    api: DexApi,
+    adapter: DexAdapter,
     msg: DexExecuteMsg,
 ) -> DexResult {
     match msg {
@@ -30,18 +30,18 @@ pub fn execute_handler(
             let exchange = exchange_resolver::identify_exchange(&dex_name)?;
             // if exchange is on an app-chain, execute the action on the app-chain
             if exchange.over_ibc() {
-                handle_ibc_api_request(&deps, info, &api, dex_name, &action)
+                handle_ibc_request(&deps, info, &adapter, dex_name, &action)
             } else {
                 // the action can be executed on the local chain
-                handle_local_api_request(deps, env, info, api, action, dex_name)
+                handle_local_request(deps, env, info, adapter, action, dex_name)
             }
         }
         DexExecuteMsg::UpdateFee {
             swap_fee,
-            recipient_os_id,
+            recipient_account_id,
         } => {
             // only previous OS can change the owner
-            api.account_registry(deps.as_ref())
+            adapter.account_registry(deps.as_ref())
                 .assert_proxy(&info.sender)?;
             if let Some(swap_fee) = swap_fee {
                 let mut fee = SWAP_FEE.load(deps.storage)?;
@@ -49,9 +49,9 @@ pub fn execute_handler(
                 SWAP_FEE.save(deps.storage, &fee)?;
             }
 
-            if let Some(os_id) = recipient_os_id {
+            if let Some(account_id) = recipient_account_id {
                 let mut fee = SWAP_FEE.load(deps.storage)?;
-                let recipient = api.account_registry(deps.as_ref()).proxy_address(os_id)?;
+                let recipient = adapter.account_registry(deps.as_ref()).proxy_address(account_id)?;
                 fee.set_recipient(deps.api, recipient)?;
                 SWAP_FEE.save(deps.storage, &fee)?;
             }
@@ -60,31 +60,32 @@ pub fn execute_handler(
     }
 }
 
-/// Handle an api request that can be executed on the local chain
-fn handle_local_api_request(
+/// Handle an adapter request that can be executed on the local chain
+fn handle_local_request(
     deps: DepsMut,
     _env: Env,
     _info: MessageInfo,
-    api: DexApi,
+    adapter: DexAdapter,
     action: DexAction,
     exchange: String,
 ) -> DexResult {
     let exchange = exchange_resolver::resolve_exchange(&exchange)?;
-    let (msgs, _) = api.resolve_dex_action(deps.as_ref(), action, exchange)?;
-    let proxy_msg = api.executor(deps.as_ref()).execute(msgs)?;
+    let (msgs, _) = adapter.resolve_dex_action(deps.as_ref(), action, exchange)?;
+    let proxy_msg = adapter.executor(deps.as_ref()).execute(msgs)?;
     Ok(Response::new().add_message(proxy_msg))
 }
 
-fn handle_ibc_api_request(
+// Handle an adapter request that can be executed on an IBC chain
+fn handle_ibc_request(
     deps: &DepsMut,
     info: MessageInfo,
-    api: &DexApi,
+    adapter: &DexAdapter,
     dex_name: DexName,
     action: &DexAction,
 ) -> DexResult {
     let host_chain = dex_name;
-    let ans = api.name_service(deps.as_ref());
-    let ibc_client = api.ibc_client(deps.as_ref());
+    let ans = adapter.name_service(deps.as_ref());
+    let ibc_client = adapter.ibc_client(deps.as_ref());
     // get the to-be-sent assets from the action
     let coins = resolve_assets_to_transfer(deps.as_ref(), action, ans.host())?;
     // construct the ics20 call(s)

--- a/contracts/dex/src/handlers/instantiate.rs
+++ b/contracts/dex/src/handlers/instantiate.rs
@@ -1,4 +1,4 @@
-use crate::contract::{DexApi, DexResult};
+use crate::contract::{DexAdapter, DexResult};
 use crate::{msg::DexInstantiateMsg, state::SWAP_FEE};
 use abstract_core::objects::fee::UsageFee;
 use abstract_sdk::OsVerification;
@@ -8,10 +8,10 @@ pub fn instantiate_handler(
     deps: DepsMut,
     _env: Env,
     _info: MessageInfo,
-    api: DexApi,
+    adapter: DexAdapter,
     msg: DexInstantiateMsg,
 ) -> DexResult {
-    let recipient = api
+    let recipient = adapter
         .account_registry(deps.as_ref())
         .proxy_address(msg.recipient_os)?;
     let fee = UsageFee::new(deps.api, msg.swap_fee, recipient)?;

--- a/contracts/dex/src/handlers/instantiate.rs
+++ b/contracts/dex/src/handlers/instantiate.rs
@@ -13,7 +13,7 @@ pub fn instantiate_handler(
 ) -> DexResult {
     let recipient = adapter
         .account_registry(deps.as_ref())
-        .proxy_address(msg.recipient_os)?;
+        .proxy_address(msg.recipient_account)?;
     let fee = UsageFee::new(deps.api, msg.swap_fee, recipient)?;
     SWAP_FEE.save(deps.storage, &fee)?;
     Ok(Response::default())

--- a/contracts/dex/src/handlers/query.rs
+++ b/contracts/dex/src/handlers/query.rs
@@ -13,7 +13,12 @@ use abstract_core::objects::{AssetEntry, DexAssetPairing};
 use abstract_sdk::features::AbstractNameService;
 use cosmwasm_std::{to_binary, Binary, Deps, Env, StdError};
 
-pub fn query_handler(deps: Deps, env: Env, adapter: &DexAdapter, msg: DexQueryMsg) -> DexResult<Binary> {
+pub fn query_handler(
+    deps: Deps,
+    env: Env,
+    adapter: &DexAdapter,
+    msg: DexQueryMsg,
+) -> DexResult<Binary> {
     match msg {
         DexQueryMsg::SimulateSwap {
             offer_asset,

--- a/contracts/dex/src/lib.rs
+++ b/contracts/dex/src/lib.rs
@@ -24,25 +24,25 @@ pub mod boot {
     use crate::{msg::*, EXCHANGE};
     use abstract_boot::boot_core::ContractWrapper;
     use abstract_boot::boot_core::{contract, Contract, ContractInstance, CwEnv};
-    use abstract_boot::{AbstractBootError, ApiDeployer, Manager};
+    use abstract_boot::{AbstractBootError, AdapterDeployer, Manager};
     use abstract_core::{
-        api::{self},
+        adapter::{self},
         objects::{AnsAsset, AssetEntry},
         MANAGER,
     };
     use cosmwasm_std::{Decimal, Empty};
 
     #[contract(InstantiateMsg, ExecuteMsg, QueryMsg, Empty)]
-    pub struct DexApi<Chain>;
+    pub struct DexAdapter<Chain>;
 
     // Implement deployer trait
-    impl<Chain: CwEnv> ApiDeployer<Chain, DexInstantiateMsg> for DexApi<Chain> {}
+    impl<Chain: CwEnv> AdapterDeployer<Chain, DexInstantiateMsg> for DexAdapter<Chain> {}
 
-    impl<Chain: CwEnv> DexApi<Chain> {
+    impl<Chain: CwEnv> DexAdapter<Chain> {
         pub fn new(name: &str, chain: Chain) -> Self {
             Self(
                 Contract::new(name, chain)
-                    .with_wasm_path("abstract_dex_api")
+                    .with_wasm_path("abstract_dex_adapter")
                     .with_mock(Box::new(ContractWrapper::new_with_empty(
                         crate::contract::execute,
                         crate::contract::instantiate,
@@ -62,7 +62,7 @@ pub mod boot {
             let asset = AssetEntry::new(offer_asset.0);
             let ask_asset = AssetEntry::new(ask_asset);
 
-            let swap_msg = crate::msg::ExecuteMsg::Module(api::ApiRequestMsg {
+            let swap_msg = crate::msg::ExecuteMsg::Module(adapter::AdapterRequestMsg {
                 proxy_address: None,
                 request: DexExecuteMsg::Action {
                     dex,

--- a/contracts/dex/src/msg.rs
+++ b/contracts/dex/src/msg.rs
@@ -22,7 +22,7 @@ impl adapter::AdapterQueryMsg for DexQueryMsg {}
 #[cosmwasm_schema::cw_serde]
 pub struct DexInstantiateMsg {
     pub swap_fee: Decimal,
-    pub recipient_os: u32,
+    pub recipient_account: u32,
 }
 
 /// Dex Execute msg
@@ -30,7 +30,7 @@ pub struct DexInstantiateMsg {
 pub enum DexExecuteMsg {
     UpdateFee {
         swap_fee: Option<Decimal>,
-        recipient_account_id: Option<u32>,
+        recipient_account: Option<u32>,
     },
     Action {
         dex: DexName,

--- a/contracts/dex/src/msg.rs
+++ b/contracts/dex/src/msg.rs
@@ -2,7 +2,10 @@
 //!
 //! [`abstract_dex_adapter`] is a generic dex-interfacing contract that handles address retrievals and dex-interactions.
 
-use abstract_core::{adapter, objects::{AnsAsset, AssetEntry, DexAssetPairing}};
+use abstract_core::{
+    adapter,
+    objects::{AnsAsset, AssetEntry, DexAssetPairing},
+};
 use cosmwasm_schema::QueryResponses;
 use cosmwasm_std::{CosmosMsg, Decimal, Uint128};
 

--- a/contracts/dex/src/msg.rs
+++ b/contracts/dex/src/msg.rs
@@ -1,11 +1,8 @@
-//! # Decentralized Exchange Api
+//! # Decentralized Exchange Adapter
 //!
-//! `abstract_core::dex` is a generic dex-interfacing contract that handles address retrievals and dex-interactions.
+//! [`abstract_dex_adapter`] is a generic dex-interfacing contract that handles address retrievals and dex-interactions.
 
-use abstract_core::{
-    api,
-    objects::{AnsAsset, AssetEntry, DexAssetPairing},
-};
+use abstract_core::{adapter, objects::{AnsAsset, AssetEntry, DexAssetPairing}};
 use cosmwasm_schema::QueryResponses;
 use cosmwasm_std::{CosmosMsg, Decimal, Uint128};
 
@@ -15,12 +12,12 @@ pub type AskAsset = AnsAsset;
 
 pub const IBC_DEX_ID: u32 = 11335;
 
-pub type ExecuteMsg = api::ExecuteMsg<DexExecuteMsg>;
-pub type QueryMsg = api::QueryMsg<DexQueryMsg>;
-pub type InstantiateMsg = api::InstantiateMsg<DexInstantiateMsg>;
+pub type ExecuteMsg = adapter::ExecuteMsg<DexExecuteMsg>;
+pub type QueryMsg = adapter::QueryMsg<DexQueryMsg>;
+pub type InstantiateMsg = adapter::InstantiateMsg<DexInstantiateMsg>;
 
-impl api::ApiExecuteMsg for DexExecuteMsg {}
-impl api::ApiQueryMsg for DexQueryMsg {}
+impl adapter::AdapterExecuteMsg for DexExecuteMsg {}
+impl adapter::AdapterQueryMsg for DexQueryMsg {}
 
 #[cosmwasm_schema::cw_serde]
 pub struct DexInstantiateMsg {
@@ -33,7 +30,7 @@ pub struct DexInstantiateMsg {
 pub enum DexExecuteMsg {
     UpdateFee {
         swap_fee: Option<Decimal>,
-        recipient_os_id: Option<u32>,
+        recipient_account_id: Option<u32>,
     },
     Action {
         dex: DexName,
@@ -41,8 +38,8 @@ pub enum DexExecuteMsg {
     },
 }
 
-#[cosmwasm_schema::cw_serde]
 /// Possible actions to perform on the DEX
+#[cosmwasm_schema::cw_serde]
 pub enum DexAction {
     /// Provide arbitrary liquidity
     ProvideLiquidity {
@@ -114,8 +111,8 @@ pub struct SimulateSwapResponse {
     pub spread_amount: Uint128,
     /// Commission charged for the swap
     pub commission: (AssetEntry, Uint128),
-    /// API fee charged for the swap (paid in offer asset)
-    pub api_fee: Uint128,
+    /// Adapter fee charged for the swap (paid in offer asset)
+    pub usage_fee: Uint128,
 }
 
 /// Response from GenerateMsgs

--- a/contracts/dex/tests/common/mod.rs
+++ b/contracts/dex/tests/common/mod.rs
@@ -6,7 +6,9 @@ use abstract_core::objects::gov_type::GovernanceDetails;
 use abstract_boot::boot_core::Mock;
 use cosmwasm_std::Addr;
 
-pub fn create_default_account(factory: &AccountFactory<Mock>) -> anyhow::Result<AbstractAccount<Mock>> {
+pub fn create_default_account(
+    factory: &AccountFactory<Mock>,
+) -> anyhow::Result<AbstractAccount<Mock>> {
     let os = factory.create_default_account(GovernanceDetails::Monarchy {
         monarch: Addr::unchecked(ROOT_USER).to_string(),
     })?;

--- a/contracts/dex/tests/common/mod.rs
+++ b/contracts/dex/tests/common/mod.rs
@@ -6,36 +6,36 @@ use abstract_core::objects::gov_type::GovernanceDetails;
 use abstract_boot::boot_core::Mock;
 use cosmwasm_std::Addr;
 
-pub fn create_default_os(factory: &AccountFactory<Mock>) -> anyhow::Result<AbstractAccount<Mock>> {
+pub fn create_default_account(factory: &AccountFactory<Mock>) -> anyhow::Result<AbstractAccount<Mock>> {
     let os = factory.create_default_account(GovernanceDetails::Monarchy {
         monarch: Addr::unchecked(ROOT_USER).to_string(),
     })?;
     Ok(os)
 }
 
-// /// Instantiates the dex api and registers it with the version control
+// /// Instantiates the dex adapter and registers it with the version control
 // #[allow(dead_code)]
-// pub fn init_dex_api(
+// pub fn init_dex_adapter(
 //     chain: Mock,
 //     deployment: &Abstract<Mock>,
 //     version: Option<String>,
-// ) -> anyhow::Result<DexApi<Mock>> {
-//     let mut dex_api = DexApi::new(EXCHANGE, chain);
-//     dex_api
+// ) -> anyhow::Result<DexAdapter<Mock>> {
+//     let mut dex_adapter = DexAdapter::new(EXCHANGE, chain);
+//     dex_adapter
 //         .as_instance_mut()
 //         .set_mock(Box::new(boot_core::ContractWrapper::new_with_empty(
 //             ::dex::contract::execute,
 //             ::dex::contract::instantiate,
 //             ::dex::contract::query,
 //         )));
-//     dex_api.upload()?;
-//     dex_api.instantiate(
+//     dex_adapter.upload()?;
+//     dex_adapter.instantiate(
 //         &InstantiateMsg::<DexInstantiateMsg>{
 //             app: DexInstantiateMsg{
 //                 swap_fee: Decimal::percent(1),
 //                 recipient_os: 0,
 //             },
-//             base: abstract_core::api::BaseInstantiateMsg {
+//             base: abstract_core::adapter::BaseInstantiateMsg {
 //                 ans_host_address: deployment.ans_host.addr_str()?,
 //                 version_control_address: deployment.version_control.addr_str()?,
 //             },
@@ -50,6 +50,6 @@ pub fn create_default_os(factory: &AccountFactory<Mock>) -> anyhow::Result<Abstr
 
 //     deployment
 //         .version_control
-//         .register_apis(vec![dex_api.as_instance()], &version)?;
-//     Ok(dex_api)
+//         .register_adapters(vec![dex_adapter.as_instance()], &version)?;
+//     Ok(dex_adapter)
 // }

--- a/contracts/dex/tests/swap.rs
+++ b/contracts/dex/tests/swap.rs
@@ -31,7 +31,7 @@ fn setup_mock() -> anyhow::Result<(
         "1.0.0".parse()?,
         DexInstantiateMsg {
             swap_fee: Decimal::percent(1),
-            recipient_os: 0,
+            recipient_account: 0,
         },
     )?;
 

--- a/contracts/dex/tests/swap.rs
+++ b/contracts/dex/tests/swap.rs
@@ -84,7 +84,7 @@ fn swap_raw() -> anyhow::Result<()> {
     wyndex
         .raw_token
         .call_as(&owner)
-        .transfer(10_000u128.into(), (&proxy_addr).to_string())?;
+        .transfer(10_000u128.into(), proxy_addr.to_string())?;
 
     // swap 100 RAW to EUR
     dex_adapter.swap((RAW_TOKEN, 100), EUR, wyndex_bundle::WYNDEX.into())?;
@@ -97,9 +97,7 @@ fn swap_raw() -> anyhow::Result<()> {
     assert_that!(eur_balance.u128()).is_equal_to(10098);
 
     // assert that OS 0 received the swap fee
-    let account0_proxy = AbstractAccount::new(chain.clone(), Some(0))
-        .proxy
-        .address()?;
+    let account0_proxy = AbstractAccount::new(chain, Some(0)).proxy.address()?;
     let os0_raw_balance = wyndex.raw_token.balance(account0_proxy.to_string())?;
     assert_that!(os0_raw_balance.balance.u128()).is_equal_to(1);
 

--- a/contracts/tendermint-staking/Cargo.toml
+++ b/contracts/tendermint-staking/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "abstract-tendermint-staking-api"
+name = "abstract-tendermint-staking-adapter"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
@@ -23,10 +23,10 @@ cosmwasm-schema = { workspace = true }
 thiserror = { workspace = true }
 abstract-core = { workspace = true }
 abstract-sdk = { workspace = true }
-abstract-api = { workspace = true }
+abstract-adapter = { workspace = true }
 
 boot-core = { workspace = true, optional = true }
 abstract-boot = { workspace = true, optional = true }
 
 [dev-dependencies]
-abstract-api = { workspace = true, features = ["schema"] }
+abstract-adapter = { workspace = true, features = ["schema"] }

--- a/contracts/tendermint-staking/README.md
+++ b/contracts/tendermint-staking/README.md
@@ -1,6 +1,6 @@
-# TendermintStake Api
+# TendermintStake Adapter
 
-Api to easily delegate and claim rewards from validators.
+Adapter module to easily delegate and claim rewards from validators.
 
 # Features
 

--- a/contracts/tendermint-staking/examples/schema.rs
+++ b/contracts/tendermint-staking/examples/schema.rs
@@ -1,4 +1,4 @@
-use abstract_tendermint_staking_api::contract::TendermintStakeApi;
+use abstract_tendermint_staking_adapter::contract::TendermintStakeAdapter;
 use cosmwasm_schema::remove_schemas;
 use std::env::current_dir;
 use std::fs::create_dir_all;
@@ -9,5 +9,5 @@ fn main() {
     create_dir_all(&out_dir).unwrap();
     remove_schemas(&out_dir).unwrap();
 
-    TendermintStakeApi::export_schema(&out_dir);
+    TendermintStakeAdapter::export_schema(&out_dir);
 }

--- a/contracts/tendermint-staking/src/error.rs
+++ b/contracts/tendermint-staking/src/error.rs
@@ -1,4 +1,4 @@
-use abstract_api::ApiError;
+use abstract_adapter::AdapterError;
 use abstract_sdk::AbstractSdkError;
 use cosmwasm_std::StdError;
 use thiserror::Error;
@@ -12,5 +12,5 @@ pub enum TendermintStakeError {
     AbstractSdk(#[from] AbstractSdkError),
 
     #[error("{0}")]
-    ApiError(#[from] ApiError),
+    AdapterError(#[from] AdapterError),
 }

--- a/contracts/tendermint-staking/src/lib.rs
+++ b/contracts/tendermint-staking/src/lib.rs
@@ -7,24 +7,26 @@ pub const TENDERMINT_STAKING: &str = "abstract:tendermint-staking";
 
 #[cfg(feature = "boot")]
 pub mod boot {
-    use abstract_boot::boot_core::ContractWrapper;
-    use abstract_boot::boot_core::{contract, Contract, CwEnv};
-    use abstract_boot::ApiDeployer;
-    use abstract_core::api::InstantiateMsg;
+    use abstract_boot::{
+        boot_core::ContractWrapper,
+        boot_core::{contract, Contract, CwEnv},
+        AdapterDeployer
+    };
+    use abstract_core::adapter::InstantiateMsg;
     use cosmwasm_std::Empty;
 
     use crate::msg::*;
 
     #[contract(InstantiateMsg, ExecuteMsg, QueryMsg, Empty)]
-    pub struct TMintStakingApi<Chain>;
+    pub struct TMintStakingAdapter<Chain>;
 
-    impl<Chain: CwEnv> ApiDeployer<Chain, Empty> for TMintStakingApi<Chain> {}
+    impl<Chain: CwEnv> AdapterDeployer<Chain, Empty> for TMintStakingAdapter<Chain> {}
 
-    impl<Chain: CwEnv> TMintStakingApi<Chain> {
+    impl<Chain: CwEnv> TMintStakingAdapter<Chain> {
         pub fn new(name: &str, chain: Chain) -> Self {
             Self(
                 Contract::new(name, chain)
-                    .with_wasm_path("abstract_tendermint_staking_api")
+                    .with_wasm_path("abstract_tendermint_staking_adapter")
                     .with_mock(Box::new(ContractWrapper::new_with_empty(
                         crate::contract::execute,
                         crate::contract::instantiate,

--- a/contracts/tendermint-staking/src/lib.rs
+++ b/contracts/tendermint-staking/src/lib.rs
@@ -10,7 +10,7 @@ pub mod boot {
     use abstract_boot::{
         boot_core::ContractWrapper,
         boot_core::{contract, Contract, CwEnv},
-        AdapterDeployer
+        AdapterDeployer,
     };
     use abstract_core::adapter::InstantiateMsg;
     use cosmwasm_std::Empty;

--- a/contracts/tendermint-staking/src/msg.rs
+++ b/contracts/tendermint-staking/src/msg.rs
@@ -1,16 +1,16 @@
-//! # Tendermint Staking Api
+//! # Tendermint Staking Adapter
 //!
 //! `abstract_core::tendermint_staking` exposes all the function of [`cosmwasm_std::CosmosMsg::Staking`] and [`cosmwasm_std::CosmosMsg::Distribution`].
 
-use abstract_core::api;
+use abstract_core::adapter;
 use cosmwasm_schema::QueryResponses;
 use cosmwasm_std::Uint128;
 
-pub type ExecuteMsg = api::ExecuteMsg<TendermintStakingExecuteMsg>;
-pub type QueryMsg = api::QueryMsg<TendermintStakingQueryMsg>;
+pub type ExecuteMsg = adapter::ExecuteMsg<TendermintStakingExecuteMsg>;
+pub type QueryMsg = adapter::QueryMsg<TendermintStakingQueryMsg>;
 
-impl api::ApiExecuteMsg for TendermintStakingExecuteMsg {}
-impl api::ApiQueryMsg for TendermintStakingQueryMsg {}
+impl adapter::AdapterExecuteMsg for TendermintStakingExecuteMsg {}
+impl adapter::AdapterQueryMsg for TendermintStakingQueryMsg {}
 
 #[cosmwasm_schema::cw_serde]
 #[cfg_attr(feature = "boot", derive(boot_core::ExecuteFns))]

--- a/justfile
+++ b/justfile
@@ -32,7 +32,7 @@ watch-test:
 
 # `just wasm-module cw-staking --features export,terra --no-default-features`
 wasm-contract module +args='':
-  RUSTFLAGS='-C link-arg=-s' cargo wasm --package abstract-{{module}}-api {{args}}
+  RUSTFLAGS='-C link-arg=-s' cargo wasm --package abstract-{{module}} {{args}}
 
 # Wasm all the contracts in the repository for the given chain
 wasm chain_name:
@@ -45,7 +45,7 @@ wasm chain_name:
 # ??? deploy-module module +args='': (wasm-module module)
 # `just deploy-module dex pisco-1`
 deploy-contract module network +args='':
-  cargo deploy --package abstract-{{module}}-api -- --network-id {{network}} {{args}}
+  cargo deploy --package abstract-{{module}} -- --network-id {{network}} {{args}}
 
 # Deploy all the apis
 deploy network +args='':

--- a/publish/publish.sh
+++ b/publish/publish.sh
@@ -14,9 +14,9 @@ then
 fi
 
 # these are imported by other packages
-APIS="dex cw-staking tendermint-staking"
+ADAPTERS="dex cw-staking tendermint-staking"
 
- for pack in $APIS; do
+ for pack in $ADAPTERS; do
    (
      cd "contracts/$pack"
      echo "Publishing base $pack"


### PR DESCRIPTION
This change does the refactor away from `api` as a module term to `adapter`.

It should be noted that this change *also* removes the use of "os" in the `DexAction`, and now reads as follows:
```rust
#[cosmwasm_schema::cw_serde]
pub struct DexInstantiateMsg {
    pub swap_fee: Decimal,
    pub recipient_account: u32,
}

/// Dex Execute msg
#[cosmwasm_schema::cw_serde]
pub enum DexExecuteMsg {
    UpdateFee {
        swap_fee: Option<Decimal>,
        recipient_account: Option<u32>,
    },
    Action {
        dex: DexName,
        action: DexAction,
    },
}
```