### PR TITLE
CU-866a8c9g4 - Rename dex and staking traits

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    "spellright.language": [
+        "en"
+    ],
+    "spellright.documentTypes": [
+        "markdown",
+        "latex",
+        "plaintext"
+    ]
+}

--- a/contracts/cw-staking/src/contract.rs
+++ b/contracts/cw-staking/src/contract.rs
@@ -6,10 +6,14 @@ use cosmwasm_std::{Empty, Response};
 
 const MODULE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
+/// Staking contract adapter interface
 pub type CwStakingAdapter =
     AdapterContract<StakingError, Empty, CwStakingExecuteMsg, CwStakingQueryMsg>;
+
+/// Staking operation result
 pub type CwStakingResult<T = Response> = Result<T, StakingError>;
 
+/// Staking contract adapter
 pub const CW_STAKING_ADAPTER: CwStakingAdapter =
     CwStakingAdapter::new(CW_STAKING, MODULE_VERSION, None)
         .with_execute(handlers::execute_handler)

--- a/contracts/cw-staking/src/handlers/execute.rs
+++ b/contracts/cw-staking/src/handlers/execute.rs
@@ -1,7 +1,7 @@
 use crate::contract::{CwStakingAdapter, CwStakingResult};
 use crate::msg::{CwStakingAction, CwStakingExecuteMsg, ProviderName, IBC_STAKING_PROVIDER_ID};
 use crate::providers::resolver::{self, is_over_ibc};
-use crate::LocalCwStaking;
+use crate::LocalStakingCommand;
 use abstract_sdk::core::ibc_client::CallbackInfo;
 use abstract_sdk::feature_objects::AnsHost;
 use abstract_sdk::features::{AbstractNameService, AbstractResponse};
@@ -10,6 +10,7 @@ use cosmwasm_std::{to_binary, Coin, Deps, DepsMut, Env, MessageInfo, Response};
 
 const ACTION_RETRIES: u8 = 3;
 
+/// Execute staking operation
 pub fn execute_handler(
     deps: DepsMut,
     env: Env,

--- a/contracts/cw-staking/src/handlers/query.rs
+++ b/contracts/cw-staking/src/handlers/query.rs
@@ -83,7 +83,7 @@ pub fn query_handler(
                 let mut provider = resolver::resolve_local_provider(&provider)
                     .map_err(|e| StdError::generic_err(e.to_string()))?;
                 provider.fetch_data(deps, env, ans_host, staking_token)?;
-                Ok(to_binary(&provider.query_reward_tokens(&deps.querier)?)?)
+                Ok(to_binary(&provider.query_rewards(&deps.querier)?)?)
             }
         }
     }

--- a/contracts/cw-staking/src/lib.rs
+++ b/contracts/cw-staking/src/lib.rs
@@ -6,8 +6,8 @@ mod providers;
 mod handlers;
 mod traits;
 
-pub use traits::cw_staking_adapter::CwStakingAdapter;
-pub use traits::local_cw_staking::LocalCwStaking;
+pub use traits::cw_staking_adapter::StakingCommand;
+pub use traits::local_cw_staking::LocalStakingCommand;
 
 pub const CW_STAKING: &str = "abstract:cw-staking";
 

--- a/contracts/cw-staking/src/providers/astroport.rs
+++ b/contracts/cw-staking/src/providers/astroport.rs
@@ -1,5 +1,5 @@
 use crate::error::StakingError;
-use crate::traits::cw_staking_adapter::CwStakingAdapter;
+use crate::traits::cw_staking_adapter::StakingCommand;
 use crate::traits::identify::Identify;
 use abstract_sdk::{
     core::objects::{AssetEntry, LpToken},
@@ -50,8 +50,7 @@ impl Identify for Astroport {
     }
 }
 
-impl CwStakingAdapter for Astroport {
-    // get the relevant data for Astroport staking
+impl StakingCommand for Astroport {
     fn fetch_data(
         &mut self,
         deps: Deps,
@@ -184,7 +183,7 @@ impl CwStakingAdapter for Astroport {
         Ok(UnbondingResponse { claims: vec![] })
     }
 
-    fn query_reward_tokens(
+    fn query_rewards(
         &self,
         querier: &QuerierWrapper,
     ) -> Result<crate::msg::RewardTokensResponse, StakingError> {

--- a/contracts/cw-staking/src/providers/junoswap.rs
+++ b/contracts/cw-staking/src/providers/junoswap.rs
@@ -1,6 +1,6 @@
 use crate::contract::CwStakingResult;
 use crate::msg::{Claim, StakeResponse, StakingInfoResponse, UnbondingResponse};
-use crate::traits::cw_staking_adapter::CwStakingAdapter;
+use crate::traits::cw_staking_adapter::StakingCommand;
 use crate::traits::identify::Identify;
 use crate::{error::StakingError, msg::RewardTokensResponse};
 use abstract_sdk::{
@@ -41,8 +41,7 @@ impl Identify for JunoSwap {
     }
 }
 
-impl CwStakingAdapter for JunoSwap {
-    // get the relevant data for Junoswap staking
+impl StakingCommand for JunoSwap {
     fn fetch_data(
         &mut self,
         deps: Deps,
@@ -162,10 +161,8 @@ impl CwStakingAdapter for JunoSwap {
             .collect();
         Ok(UnbondingResponse { claims })
     }
-    fn query_reward_tokens(
-        &self,
-        _querier: &QuerierWrapper,
-    ) -> CwStakingResult<RewardTokensResponse> {
+
+    fn query_rewards(&self, _querier: &QuerierWrapper) -> CwStakingResult<RewardTokensResponse> {
         todo!()
     }
 }

--- a/contracts/cw-staking/src/providers/osmosis.rs
+++ b/contracts/cw-staking/src/providers/osmosis.rs
@@ -14,9 +14,10 @@ impl Identify for Osmosis {
         OSMOSIS
     }
 }
+
 #[cfg(feature = "osmosis")]
 pub mod fns {
-    use crate::CwStakingAdapter;
+    use crate::StakingCommand;
 
     use super::*;
     const FORTEEN_DAYS: i64 = 60 * 60 * 24 * 14;
@@ -64,8 +65,10 @@ pub mod fns {
 
             // TODO: this is the gamm pool address/number. Im not sure how this will be read/stored
             self.pool_addr = Some(pool_addr); // Some(Addr::unchecked("gamm/pool/69"));
-                                              // TODO: this is the gamm pool id. Im not sure how this will be read/stored
+
+            // TODO: this is the gamm pool id. Im not sure how this will be read/stored
             self.pool_id = Some(69);
+
             Ok(())
         }
 

--- a/contracts/cw-staking/src/providers/resolver.rs
+++ b/contracts/cw-staking/src/providers/resolver.rs
@@ -1,11 +1,13 @@
 use crate::error::StakingError;
-use crate::CwStakingAdapter;
+use crate::StakingCommand;
 use cosmwasm_std::{StdError, StdResult};
 
 #[cfg(feature = "terra")]
 use super::astroport::{Astroport, ASTROPORT};
+
 #[cfg(any(feature = "juno", feature = "osmosis"))]
 pub use crate::providers::osmosis::{Osmosis, OSMOSIS};
+
 #[cfg(feature = "juno")]
 pub use crate::providers::{
     junoswap::{JunoSwap, JUNOSWAP},
@@ -29,9 +31,7 @@ pub(crate) fn is_over_ibc(provider: &str) -> StdResult<bool> {
 }
 
 /// Given the provider name, return the local provider implementation
-pub(crate) fn resolve_local_provider(
-    name: &str,
-) -> Result<Box<dyn CwStakingAdapter>, StakingError> {
+pub(crate) fn resolve_local_provider(name: &str) -> Result<Box<dyn StakingCommand>, StakingError> {
     match name {
         #[cfg(feature = "juno")]
         JUNOSWAP => Ok(Box::<JunoSwap>::default()),

--- a/contracts/cw-staking/src/providers/wyndex.rs
+++ b/contracts/cw-staking/src/providers/wyndex.rs
@@ -1,7 +1,7 @@
 use crate::msg::{
     Claim, RewardTokensResponse, StakeResponse, StakingInfoResponse, UnbondingResponse,
 };
-use crate::traits::cw_staking_adapter::CwStakingAdapter;
+use crate::traits::cw_staking_adapter::StakingCommand;
 use crate::traits::identify::Identify;
 use crate::{contract::CwStakingResult, error::StakingError};
 use abstract_sdk::{
@@ -52,8 +52,7 @@ impl Identify for WynDex {
     }
 }
 
-impl CwStakingAdapter for WynDex {
-    // get the relevant data for Junoswap staking
+impl StakingCommand for WynDex {
     fn fetch_data(
         &mut self,
         deps: Deps,
@@ -205,10 +204,8 @@ impl CwStakingAdapter for WynDex {
             .collect();
         Ok(UnbondingResponse { claims })
     }
-    fn query_reward_tokens(
-        &self,
-        querier: &QuerierWrapper,
-    ) -> CwStakingResult<RewardTokensResponse> {
+
+    fn query_rewards(&self, querier: &QuerierWrapper) -> CwStakingResult<RewardTokensResponse> {
         let resp: DistributionDataResponse = querier.query_wasm_smart(
             self.staking_contract_address.clone(),
             &wyndex_stake::msg::QueryMsg::DistributionData {},

--- a/contracts/cw-staking/src/traits/cw_staking_adapter.rs
+++ b/contracts/cw-staking/src/traits/cw_staking_adapter.rs
@@ -9,7 +9,7 @@ use cosmwasm_std::{Addr, CosmosMsg, Deps, Env, QuerierWrapper, Uint128};
 use cw_utils::Duration;
 
 /// Trait that defines the adapter interface for staking providers
-pub trait CwStakingAdapter: Identify {
+pub trait StakingCommand: Identify {
     /// Construct a staking contract entry from the staking token and the provider
     fn staking_entry(&self, staking_token: &AssetEntry) -> ContractEntry {
         ContractEntry {
@@ -17,16 +17,18 @@ pub trait CwStakingAdapter: Identify {
             contract: format!("staking/{staking_token}"),
         }
     }
+
     /// Retrieve the staking contract address for the pool with the provided staking token name
     fn staking_contract_address(
         &self,
         deps: Deps,
         ans_host: &AnsHost,
-        staking_token: &AssetEntry,
+        token: &AssetEntry,
     ) -> AbstractSdkResult<Addr> {
-        let provider_staking_contract_entry = self.staking_entry(staking_token);
+        let staking_contract = self.staking_entry(token);
+
         ans_host
-            .query_contract(&deps.querier, &provider_staking_contract_entry)
+            .query_contract(&deps.querier, &staking_contract)
             .map_err(Into::into)
     }
 
@@ -40,10 +42,6 @@ pub trait CwStakingAdapter: Identify {
     ) -> AbstractSdkResult<()>;
 
     /// Stake the provided asset into the staking contract
-    ///
-    /// * `deps` - the dependencies
-    /// * `asset` - the asset to stake
-    /// * `unbonding_period` - the unbonding period to use for the stake
     fn stake(
         &self,
         deps: Deps,
@@ -52,10 +50,6 @@ pub trait CwStakingAdapter: Identify {
     ) -> Result<Vec<CosmosMsg>, StakingError>;
 
     /// Stake the provided asset into the staking contract
-    ///
-    /// * `deps` - the dependencies
-    /// * `asset` - the asset to stake
-    /// * `unbonding_period` - the unbonding period to use for the unstake
     fn unstake(
         &self,
         deps: Deps,
@@ -72,21 +66,22 @@ pub trait CwStakingAdapter: Identify {
     fn claim(&self, deps: Deps) -> Result<Vec<CosmosMsg>, StakingError>;
 
     fn query_info(&self, querier: &QuerierWrapper) -> CwStakingResult<StakingInfoResponse>;
-    // This function queries the staked token balance of a staker
-    // The staking contract is queried using the staking address
+
+    /// Query the staked token balance of a given staker
     fn query_staked(
         &self,
         querier: &QuerierWrapper,
         staker: Addr,
         unbonding_period: Option<Duration>,
     ) -> CwStakingResult<StakeResponse>;
+
+    /// Query unbonding information of a given staker
     fn query_unbonding(
         &self,
         querier: &QuerierWrapper,
         staker: Addr,
     ) -> CwStakingResult<UnbondingResponse>;
-    fn query_reward_tokens(
-        &self,
-        querier: &QuerierWrapper,
-    ) -> CwStakingResult<RewardTokensResponse>;
+
+    /// Query for pending claimable rewards
+    fn query_rewards(&self, querier: &QuerierWrapper) -> CwStakingResult<RewardTokensResponse>;
 }

--- a/contracts/cw-staking/src/traits/local_cw_staking.rs
+++ b/contracts/cw-staking/src/traits/local_cw_staking.rs
@@ -1,25 +1,26 @@
 use crate::error::StakingError;
 use crate::msg::CwStakingAction;
-use crate::traits::cw_staking_adapter::CwStakingAdapter;
+use crate::traits::cw_staking_adapter::StakingCommand;
 use abstract_sdk::core::objects::AssetEntry;
 use abstract_sdk::features::AbstractNameService;
 use abstract_sdk::Execution;
 use cosmwasm_std::{DepsMut, Env, SubMsg};
 
-impl<T> LocalCwStaking for T where T: AbstractNameService + Execution {}
+impl<T> LocalStakingCommand for T where T: AbstractNameService + Execution {}
 
 /// Trait for dispatching *local* staking actions to the appropriate provider
 /// Resolves the required data for that provider
-pub trait LocalCwStaking: AbstractNameService + Execution {
+pub trait LocalStakingCommand: AbstractNameService + Execution {
     /// resolve the provided dex action on a local dex
     fn resolve_staking_action(
         &self,
         deps: DepsMut,
         env: Env,
         action: CwStakingAction,
-        mut provider: Box<dyn CwStakingAdapter>,
+        mut provider: Box<dyn StakingCommand>,
     ) -> Result<SubMsg, StakingError> {
         let staking_asset = staking_asset_from_action(&action);
+
         provider.fetch_data(
             deps.as_ref(),
             env,

--- a/contracts/dex/src/commands.rs
+++ b/contracts/dex/src/commands.rs
@@ -1,7 +1,7 @@
 use crate::msg::AskAsset;
 use crate::msg::{DexAction, OfferAsset, SwapRouter};
 use crate::state::SWAP_FEE;
-use crate::{error::DexError, DEX};
+use crate::{error::DexError, DexCommand};
 use abstract_core::objects::{DexAssetPairing, PoolReference};
 use abstract_sdk::core::objects::AnsAsset;
 use abstract_sdk::core::objects::AssetEntry;
@@ -28,7 +28,7 @@ pub trait LocalDex: AbstractNameService + Execution {
         &self,
         deps: Deps,
         action: DexAction,
-        exchange: &dyn DEX,
+        exchange: &dyn DexCommand,
     ) -> Result<(Vec<CosmosMsg>, ReplyId), DexError> {
         Ok(match action {
             DexAction::ProvideLiquidity { assets, max_spread } => {
@@ -102,7 +102,7 @@ pub trait LocalDex: AbstractNameService + Execution {
         deps: Deps,
         offer_asset: OfferAsset,
         mut ask_asset: AssetEntry,
-        exchange: &dyn DEX,
+        exchange: &dyn DexCommand,
         max_spread: Option<Decimal>,
         belief_price: Option<Decimal>,
     ) -> Result<Vec<CosmosMsg>, DexError> {
@@ -145,7 +145,7 @@ pub trait LocalDex: AbstractNameService + Execution {
         _deps: Deps,
         _offer_assets: Vec<OfferAsset>,
         _ask_assets: Vec<AskAsset>,
-        _exchange: &dyn DEX,
+        _exchange: &dyn DexCommand,
         _max_spread: Option<Decimal>,
         _router: Option<SwapRouter>,
     ) -> Result<Vec<CosmosMsg>, DexError> {
@@ -177,7 +177,7 @@ pub trait LocalDex: AbstractNameService + Execution {
         &self,
         deps: Deps,
         offer_assets: Vec<OfferAsset>,
-        exchange: &dyn DEX,
+        exchange: &dyn DexCommand,
         max_spread: Option<Decimal>,
     ) -> Result<Vec<CosmosMsg>, DexError> {
         let ans = self.name_service(deps);
@@ -202,7 +202,7 @@ pub trait LocalDex: AbstractNameService + Execution {
         deps: Deps,
         offer_asset: OfferAsset,
         mut paired_assets: Vec<AssetEntry>,
-        exchange: &dyn DEX,
+        exchange: &dyn DexCommand,
     ) -> Result<Vec<CosmosMsg>, DexError> {
         let ans = self.name_service(deps);
         let paired_asset_infos = ans.query(&paired_assets)?;
@@ -220,7 +220,7 @@ pub trait LocalDex: AbstractNameService + Execution {
         &self,
         deps: Deps,
         lp_token: OfferAsset,
-        exchange: &dyn DEX,
+        exchange: &dyn DexCommand,
     ) -> Result<Vec<CosmosMsg>, DexError> {
         let ans = self.name_service(deps);
 

--- a/contracts/dex/src/dex_trait.rs
+++ b/contracts/dex/src/dex_trait.rs
@@ -15,9 +15,12 @@ pub trait Identify {
     fn name(&self) -> &'static str;
 }
 
-/// DEX ensures supported dexes support the expected functionality.
-/// Trait that implements the actual dex interaction.
-pub trait DEX: Identify {
+/// # DexCommand
+/// ensures DEX adapters support the expected functionality.
+///
+/// Implements the usual DEX operations.
+pub trait DexCommand: Identify {
+    /// Return pool information for given assets pair
     fn pair_address(
         &self,
         deps: Deps,
@@ -32,6 +35,8 @@ pub trait DEX: Identify {
         })?;
         Ok(found.pool_address)
     }
+
+    /// Execute a swap on the given DEX using the swap in question custom logic
     #[allow(clippy::too_many_arguments)]
     fn swap(
         &self,
@@ -42,6 +47,8 @@ pub trait DEX: Identify {
         belief_price: Option<Decimal>,
         max_spread: Option<Decimal>,
     ) -> Result<Vec<CosmosMsg>, DexError>;
+
+    /// Implement your custom swap the DEX
     fn custom_swap(
         &self,
         _deps: Deps,
@@ -52,6 +59,8 @@ pub trait DEX: Identify {
         // Must be implemented in the base to be available
         Err(DexError::NotImplemented(self.name().to_string()))
     }
+
+    /// Provides liquidity on the the DEX
     fn provide_liquidity(
         &self,
         deps: Deps,
@@ -59,6 +68,8 @@ pub trait DEX: Identify {
         offer_assets: Vec<Asset>,
         max_spread: Option<Decimal>,
     ) -> Result<Vec<CosmosMsg>, DexError>;
+
+    /// Provide symmetric liquidity where available depending on the DEX
     fn provide_liquidity_symmetric(
         &self,
         deps: Deps,
@@ -66,17 +77,16 @@ pub trait DEX: Identify {
         offer_asset: Asset,
         paired_assets: Vec<AssetInfo>,
     ) -> Result<Vec<CosmosMsg>, DexError>;
-    // fn raw_swap();
-    // fn raw_provide_liquidity();
+
+    /// Withdraw liquidity from DEX
     fn withdraw_liquidity(
         &self,
         deps: Deps,
         pool_id: PoolAddress,
         lp_token: Asset,
     ) -> Result<Vec<CosmosMsg>, DexError>;
-    // fn raw_withdraw_liquidity();
-    // fn route_swap();
-    // fn raw_route_swap();
+
+    /// Simulate a swap in the DEX
     fn simulate_swap(
         &self,
         deps: Deps,
@@ -84,4 +94,10 @@ pub trait DEX: Identify {
         offer_asset: Asset,
         ask_asset: AssetInfo,
     ) -> Result<(Return, Spread, Fee, FeeOnInput), DexError>;
+
+    // fn raw_swap();
+    // fn raw_provide_liquidity();
+    // fn raw_withdraw_liquidity();
+    // fn route_swap();
+    // fn raw_route_swap();
 }

--- a/contracts/dex/src/exchanges/astroport.rs
+++ b/contracts/dex/src/exchanges/astroport.rs
@@ -2,7 +2,7 @@ use crate::{
     commands::{coins_in_assets, cw_approve_msgs},
     dex_trait::{Fee, FeeOnInput, Identify, Return, Spread},
     error::DexError,
-    DEX,
+    DexCommand,
 };
 use abstract_core::objects::PoolAddress;
 use abstract_sdk::cw_helpers::cosmwasm_std::wasm_smart_query;
@@ -31,7 +31,7 @@ pub enum StubCw20HookMsg {
     WithdrawLiquidity {},
 }
 
-impl DEX for Astroport {
+impl DexCommand for Astroport {
     fn swap(
         &self,
         _deps: Deps,

--- a/contracts/dex/src/exchanges/exchange_resolver.rs
+++ b/contracts/dex/src/exchanges/exchange_resolver.rs
@@ -1,6 +1,6 @@
 use crate::dex_trait::Identify;
 use crate::error::DexError;
-use crate::DEX;
+use crate::DexCommand;
 
 // Supported exchanges on Juno
 #[cfg(feature = "juno")]
@@ -36,7 +36,7 @@ pub(crate) fn identify_exchange(value: &str) -> Result<&'static dyn Identify, De
     }
 }
 
-pub(crate) fn resolve_exchange(value: &str) -> Result<&'static dyn DEX, DexError> {
+pub(crate) fn resolve_exchange(value: &str) -> Result<&'static dyn DexCommand, DexError> {
     match value {
         #[cfg(feature = "juno")]
         JUNOSWAP => Ok(&JunoSwap {}),

--- a/contracts/dex/src/exchanges/junoswap.rs
+++ b/contracts/dex/src/exchanges/junoswap.rs
@@ -2,7 +2,7 @@ use crate::{
     commands::{coins_in_assets, cw_approve_msgs},
     dex_trait::{Fee, FeeOnInput, Return, Spread},
 };
-use crate::{dex_trait::Identify, error::DexError, DEX};
+use crate::{dex_trait::Identify, error::DexError, DexCommand};
 use abstract_core::objects::PoolAddress;
 use abstract_sdk::cw_helpers::cosmwasm_std::wasm_smart_query;
 use cosmwasm_std::{
@@ -26,7 +26,7 @@ impl Identify for JunoSwap {
     }
 }
 
-impl DEX for JunoSwap {
+impl DexCommand for JunoSwap {
     fn swap(
         &self,
         deps: Deps,

--- a/contracts/dex/src/exchanges/osmosis.rs
+++ b/contracts/dex/src/exchanges/osmosis.rs
@@ -4,7 +4,7 @@ use crate::dex_trait::Identify;
 use crate::{
     dex_trait::{Fee, FeeOnInput, Return, Spread},
     error::DexError,
-    DEX,
+    DexCommand,
 };
 use cosmwasm_std::Addr;
 
@@ -44,7 +44,7 @@ impl Identify for Osmosis {
 
 /// Osmosis app-chain dex implementation
 #[cfg(feature = "osmosis")]
-impl DEX for Osmosis {
+impl DexCommand for Osmosis {
     fn swap(
         &self,
         _deps: Deps,

--- a/contracts/dex/src/exchanges/terraswap.rs
+++ b/contracts/dex/src/exchanges/terraswap.rs
@@ -2,7 +2,7 @@ use crate::{
     commands::{coins_in_assets, cw_approve_msgs},
     dex_trait::{Fee, FeeOnInput, Identify, Return, Spread},
     error::DexError,
-    DEX,
+    DexCommand,
 };
 use abstract_core::objects::PoolAddress;
 use abstract_sdk::cw_helpers::cosmwasm_std::wasm_smart_query;
@@ -24,7 +24,7 @@ impl Identify for Terraswap {
     }
 }
 
-impl DEX for Terraswap {
+impl DexCommand for Terraswap {
     fn swap(
         &self,
         _deps: Deps,

--- a/contracts/dex/src/exchanges/wyndex.rs
+++ b/contracts/dex/src/exchanges/wyndex.rs
@@ -2,7 +2,7 @@ use crate::{
     commands::{coins_in_assets, cw_approve_msgs},
     dex_trait::{Fee, FeeOnInput, Identify, Return, Spread},
     error::DexError,
-    DEX,
+    DexCommand,
 };
 use abstract_core::objects::PoolAddress;
 use abstract_sdk::cw_helpers::cosmwasm_std::wasm_smart_query;
@@ -31,7 +31,7 @@ pub enum StubCw20HookMsg {
     WithdrawLiquidity {},
 }
 
-impl DEX for WynDex {
+impl DexCommand for WynDex {
     fn swap(
         &self,
         _deps: Deps,

--- a/contracts/dex/src/handlers/execute.rs
+++ b/contracts/dex/src/handlers/execute.rs
@@ -78,7 +78,7 @@ fn handle_local_request(
     Ok(Response::new().add_message(proxy_msg))
 }
 
-// Handle an adapter request that can be executed on an IBC chain
+/// Handle an adapter request that can be executed on an IBC chain
 fn handle_ibc_request(
     deps: &DepsMut,
     info: MessageInfo,

--- a/contracts/dex/src/lib.rs
+++ b/contracts/dex/src/lib.rs
@@ -10,7 +10,7 @@ pub(crate) mod handlers;
 pub mod state;
 
 pub use commands::LocalDex;
-pub use dex_trait::DEX;
+pub use dex_trait::DexCommand;
 
 pub const EXCHANGE: &str = "abstract:dex";
 


### PR DESCRIPTION
# CU-866a8c9g4 - Rename dex and staking traits

* Renamed the traits
* Added comments here and there
* Added a few newlines

I thought of renaming some of the methods of staking with redundancy in their names: `query_`
But after a search in the organization I was not sure 100% of non breaking changes.
So I'm leaving that for another PR.
